### PR TITLE
DOCS(docker): Document Docker Compose '--build' switch.

### DIFF
--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -14,4 +14,4 @@ services:
     volumes:
       - ./murmur.ini:/etc/murmur/murmur.ini
       - ./data:/var/lib/murmur/
-    restart: always
+    restart: unless-stopped


### PR DESCRIPTION
-------

As discussed on #5435. It will restart container on daemon restart or container crashing, but will keep it off if stopped manually.
See [docs](https://docs.docker.com/config/containers/start-containers-automatically/) for reference.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)